### PR TITLE
Adding kiosk mode support for mac and gtk targets

### DIFF
--- a/src/browser/exo_browser.cc
+++ b/src/browser/exo_browser.cc
@@ -4,6 +4,7 @@
 #include "exo_browser/src/browser/exo_browser.h"
 
 #include "base/auto_reset.h"
+#include "base/command_line.h"
 #include "base/message_loop/message_loop.h"
 #include "base/path_service.h"
 #include "base/strings/string_number_conversions.h"
@@ -77,7 +78,12 @@ ExoBrowser::CreateNew(
     const std::string& icon_path)
 {
   ExoBrowser* browser = new ExoBrowser(wrapper);
-  browser->PlatformCreateWindow(size.width(), size.height(), icon_path);
+  
+  // Handle kiosk mode
+  const bool kiosk = 
+    CommandLine::ForCurrentProcess()->HasSwitch(switches::kExoBrowserKiosk);
+
+  browser->PlatformCreateWindow(size.width(), size.height(), kiosk, icon_path);
 
   return browser;
 }

--- a/src/browser/exo_browser.h
+++ b/src/browser/exo_browser.h
@@ -394,7 +394,7 @@ private:
   // ### PlatformCreateWindow
   //
   // Creates the ExoBrowser window GUI.
-  void PlatformCreateWindow(int width, int height, 
+  void PlatformCreateWindow(int width, int height, const bool kiosk, 
                             const std::string& icon_path);
 
   // ### PlatformKill

--- a/src/browser/exo_browser_gtk.cc
+++ b/src/browser/exo_browser_gtk.cc
@@ -35,6 +35,7 @@ void
 ExoBrowser::PlatformCreateWindow(
     int width,
     int height,
+    const bool kiosk,
     const std::string& icon_path)
 {
   window_ = GTK_WINDOW(gtk_window_new(GTK_WINDOW_TOPLEVEL));
@@ -107,6 +108,10 @@ ExoBrowser::PlatformCreateWindow(
 
   // Finally, show the window.
   gtk_widget_show_all(GTK_WIDGET(window_));
+
+  // handle kiosk mode
+  if(kiosk)
+    gtk_window_fullscreen(window_);
 }
 
 

--- a/src/browser/exo_browser_mac.mm
+++ b/src/browser/exo_browser_mac.mm
@@ -95,6 +95,7 @@ void
 ExoBrowser::PlatformCreateWindow(
     int width,
     int height,
+    const bool kiosk,
     const std::string& icon_path)
 {
   /* icon_path is ignore on OSX */
@@ -271,6 +272,22 @@ ExoBrowser::PlatformCreateWindow(
                           options:0
                           metrics:nil
                             views:horizontal_dict]];
+
+  // Handle kiosk mode
+  if(kiosk) {
+    // TODO: these might be a bit too restrictive
+    NSApplicationPresentationOptions options =
+      NSApplicationPresentationHideMenuBar |
+      NSApplicationPresentationHideDock |
+      NSApplicationPresentationDisableHideApplication |
+      NSApplicationPresentationDisableProcessSwitching |
+      NSApplicationPresentationDisableAppleMenu |
+      NSApplicationPresentationDisableForceQuit;
+
+    [NSApp setPresentationOptions:options];
+    [[_window contentView] enterFullScreenMode:
+      [NSScreen mainScreen] withOptions:nil];
+  }
 
   // show the window
   [window_ makeKeyAndOrderFront:nil];

--- a/src/common/switches.cc
+++ b/src/common/switches.cc
@@ -10,5 +10,7 @@ namespace switches {
 const char kExoBrowserDataPath[] = "data-path";
 // Prevents the launch of the default 'app/' and runs the in "raw" mode
 const char kExoBrowserRaw[] = "raw";
+// Launches ExoBrowser in fullscreen mode
+const char kExoBrowserKiosk[] = "kiosk";
 
 }  // namespace switches

--- a/src/common/switches.h
+++ b/src/common/switches.h
@@ -11,6 +11,7 @@ namespace switches {
 
 extern const char kExoBrowserDataPath[];
 extern const char kExoBrowserRaw[];
+extern const char kExoBrowserKiosk[];
 
 }  // namespace switches
 


### PR DESCRIPTION
Adds a `--kiosk` option to start exo_browser in fullscreen mode.
Implemented for GTK and Cocoa.
Tested for GTK but **NOT TESTED** on mac.

Needs a CR and testing on MAC. The options passed might be more restrictive than we need (i don't know how chrome behaves in kiosk mode on mac). I quickly put it together following [this link](https://developer.apple.com/library/mac/technotes/KioskMode/Introduction/Introduction.html).
