### PR TITLE
Prevent overflow on webview with height: 100%

### DIFF
--- a/src/renderer/extensions/resources/web_view.js
+++ b/src/renderer/extensions/resources/web_view.js
@@ -844,6 +844,7 @@ function registerBrowserPluginElement() {
     this.setAttribute('type', 'application/browser-plugin');
     this.setAttribute('id', 'browser-plugin-' + getNextId());
     // The <object> node fills in the <webview> container.
+    this.style.display = 'block';
     this.style.width = '100%';
     this.style.height = '100%';
   };


### PR DESCRIPTION
Without this, the object element gets displayed `inline` which in chromium means that it slightly exceeds it's bounds. Unfortunately there's no nice way to mitigate this issue as I can't find a way to get extra css into this intermediate page. However, forcing a block display solves the issue.